### PR TITLE
SymbolType refactoring

### DIFF
--- a/src/main/java/org/walkmod/javalang/compiler/actions/LoadStaticImportsAction.java
+++ b/src/main/java/org/walkmod/javalang/compiler/actions/LoadStaticImportsAction.java
@@ -62,8 +62,9 @@ public class LoadStaticImportsAction extends SymbolAction {
                     if (clazz == null) {
                         throw e;
                     } else {
-                        symbol.getType().setName(nameExpr);
-                        symbol.getType().getClazz();
+                        final SymbolType type = symbol.getType().withName(nameExpr);
+                        symbol.setType(type);
+                        type.getClazz();
                     }
                 }
 

--- a/src/main/java/org/walkmod/javalang/compiler/reflection/AbstractGenericsBuilderFromParameterTypes.java
+++ b/src/main/java/org/walkmod/javalang/compiler/reflection/AbstractGenericsBuilderFromParameterTypes.java
@@ -97,9 +97,7 @@ public abstract class AbstractGenericsBuilderFromParameterTypes {
                     clazz = TypesLoaderVisitor.getClassLoader().loadClass(name);
 
                     String className = clazz.getName();
-                    type = new SymbolType();
-                    type.setName(className);
-
+                    type = new SymbolType(className);
                 } catch (ClassNotFoundException e) {
                     // a name expression could be "org.walkmod.A" and this node
                     // could be "org.walkmod"

--- a/src/main/java/org/walkmod/javalang/compiler/reflection/GenericsBuilderFromArgs.java
+++ b/src/main/java/org/walkmod/javalang/compiler/reflection/GenericsBuilderFromArgs.java
@@ -92,8 +92,7 @@ public class GenericsBuilderFromArgs implements Builder<Map<String, SymbolType>>
                                                 "Invalid class into the generics resolution", e);
                                     }
 
-                                    SymbolType auxType = new SymbolType();
-                                    auxType.setName(paramClass.getName());
+                                    SymbolType auxType = new SymbolType(paramClass.getName());
                                     obj.put(variableName, auxType);
                                 }
                             }

--- a/src/main/java/org/walkmod/javalang/compiler/reflection/MethodInspector.java
+++ b/src/main/java/org/walkmod/javalang/compiler/reflection/MethodInspector.java
@@ -96,8 +96,7 @@ public class MethodInspector {
                 Method method = result.getMethod();
                 if (method != null && method.getName().equals("clone")) {
                     // JLS 10.7 - The return type of the clone method of an array type T[] is T[].
-                    result.setName(scope.getName());
-                    result.setArrayCount(scope.getArrayCount());
+                    result = result.cloneAsArray(scope.getName(), scope.getArrayCount());
                 }
             }
         }

--- a/src/main/java/org/walkmod/javalang/compiler/reflection/ResultBuilderFromGenerics.java
+++ b/src/main/java/org/walkmod/javalang/compiler/reflection/ResultBuilderFromGenerics.java
@@ -131,8 +131,8 @@ public class ResultBuilderFromGenerics implements Builder<SymbolTable> {
                         boolean isInTheTopScope = genericsSymbolTable.getScopes().peek().findSymbol(vname) != null;
                         SymbolType st = s.getType();
                         if (st != null) {
-                            SymbolType refactor =
-                                    s.getType().refactorToTypeVariable(vname, parameterizedType, genericArgs || isInTheTopScope);
+                            SymbolType refactor = s.getType().refactorToTypeVariable(vname, parameterizedType,
+                                    genericArgs || isInTheTopScope);
                             s.setType(refactor);
                         } else {
                             s.setType(parameterizedType);
@@ -211,7 +211,8 @@ public class ResultBuilderFromGenerics implements Builder<SymbolTable> {
                     for (int i = 0; i < tparams.length && it.hasNext(); i++) {
                         SymbolType st = it.next();
                         if (st != null) {
-                            updateTypeMapping(tparams[i], genericsSymbolTable, st.cloneAsTypeVariable(tparams[i].getName()), true, processed);
+                            updateTypeMapping(tparams[i], genericsSymbolTable,
+                                    st.cloneAsTypeVariable(tparams[i].getName()), true, processed);
                         }
                     }
                 }

--- a/src/main/java/org/walkmod/javalang/compiler/symbols/ASTSymbolTypeResolver.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/ASTSymbolTypeResolver.java
@@ -65,25 +65,26 @@ public class ASTSymbolTypeResolver extends GenericVisitorAdapter<SymbolType, Lis
 
     @Override
     public SymbolType visit(PrimitiveType n, List<TypeParameter> arg) {
-        SymbolType result = new SymbolType();
+        final SymbolType result;
         Primitive pt = n.getType();
         if (pt.equals(Primitive.Boolean)) {
-            result.setName(boolean.class.getName());
-
+            result = new SymbolType(boolean.class.getName());
         } else if (pt.equals(Primitive.Char)) {
-            result.setName(char.class.getName());
+            result = new SymbolType(char.class.getName());
         } else if (pt.equals(Primitive.Double)) {
-            result.setName(double.class.getName());
+            result = new SymbolType(double.class.getName());
         } else if (pt.equals(Primitive.Float)) {
-            result.setName(float.class.getName());
+            result = new SymbolType(float.class.getName());
         } else if (pt.equals(Primitive.Int)) {
-            result.setName(int.class.getName());
+            result = new SymbolType(int.class.getName());
         } else if (pt.equals(Primitive.Long)) {
-            result.setName(long.class.getName());
+            result = new SymbolType(long.class.getName());
         } else if (pt.equals(Primitive.Short)) {
-            result.setName(short.class.getName());
+            result = new SymbolType(short.class.getName());
         } else if (pt.equals(Primitive.Byte)) {
-            result.setName(byte.class.getName());
+            result = new SymbolType(byte.class.getName());
+        } else {
+            throw new IllegalArgumentException("unexpected primitive type: " + pt);
         }
         return result;
     }
@@ -208,15 +209,14 @@ public class ASTSymbolTypeResolver extends GenericVisitorAdapter<SymbolType, Lis
                         result = symbolTable.getType(scopeType.getClazz().getCanonicalName() + "." + name,
                                 org.walkmod.javalang.compiler.symbols.ReferenceType.TYPE);
                         if (result == null) {
-                            result = new SymbolType();
                             SymbolType thisType = symbolTable.getType("this");
                             if (thisType != null) {
                                 Class<?> resolvedClass = ClassInspector
                                         .findClassMember(thisType.getClazz().getPackage(), name, scopeType.getClazz());
-                                result.setName(resolvedClass.getName());
+                                result = new SymbolType(resolvedClass.getName());
                                 result.setClazz(resolvedClass);
                             } else {
-                                result.setName(scopeType.getName() + "$" + name);
+                                result = new SymbolType(scopeType.getName() + "$" + name);
                             }
                         }
                     } else {
@@ -226,10 +226,8 @@ public class ASTSymbolTypeResolver extends GenericVisitorAdapter<SymbolType, Lis
                         } catch (ClassNotFoundException e) {
                             return null;
                         }
-                        result = new SymbolType();
                         // it is a type that has not previously imported
-                        result.setName(fullName);
-
+                        result = new SymbolType(fullName);
                     }
                 }
             }

--- a/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
@@ -190,6 +190,8 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
         return name;
     }
 
+    /** @deprecated do not use directly but via specialized constructors of factory methods */
+    @Deprecated
     public void setName(String name) {
         this.name = name;
     }
@@ -487,6 +489,11 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
         for (int i = 0; i < arrayCount; i++) {
             result.append("[]");
         }
+    }
+
+    /** clone with name replaced */
+    public SymbolType withName(String name) {
+        return clone(name, arrayCount, typeVariable, null, null);
     }
 
     public SymbolType clone() {

--- a/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
@@ -494,14 +494,19 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
     }
 
     public SymbolType cloneAsTypeVariable(String typeVariable) {
-        return clone(null, null, typeVariable);
+        return clone(name, arrayCount, typeVariable, null, null);
+    }
+
+    public SymbolType cloneAsArray(String name, int arrayCount) {
+        return clone(name, arrayCount, typeVariable, null, null);
     }
 
     private SymbolType clone(final Stack<SymbolType> parent, final Stack<SymbolType> created) {
-        return clone(parent, created, typeVariable);
+        return clone(name, arrayCount, typeVariable, parent, created);
     }
 
-    private SymbolType clone(Stack<SymbolType> parent, Stack<SymbolType> created, final String typeVariable) {
+    private SymbolType clone(final String name, final int arrayCount, final String typeVariable,
+                             Stack<SymbolType> parent, Stack<SymbolType> created) {
         SymbolType result = new SymbolType(name);
         result.setClazz(clazz);
         result.setArrayCount(arrayCount);

--- a/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
@@ -501,8 +501,7 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
     }
 
     private SymbolType clone(Stack<SymbolType> parent, Stack<SymbolType> created, final String typeVariable) {
-        SymbolType result = new SymbolType();
-        result.setName(name);
+        SymbolType result = new SymbolType(name);
         result.setClazz(clazz);
         result.setArrayCount(arrayCount);
         result.setField(field);
@@ -696,16 +695,14 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
 
     private static SymbolType valueOfClass(Class<?> type, SymbolType arg, Map<String, SymbolType> updatedTypeMapping,
             Map<String, SymbolType> typeMapping) throws InvalidTypeException {
-        SymbolType returnType;
         Class<?> aux = type;
-        returnType = new SymbolType();
         int arrayCount = 0;
         while (aux.isArray()) {
             arrayCount++;
             aux = aux.getComponentType();
         }
+        final SymbolType returnType = new SymbolType(aux.getName());
         returnType.setArrayCount(arrayCount);
-        returnType.setName(aux.getName());
         Type[] typeParams = aux.getTypeParameters();
         if (typeParams.length > 0) {
 

--- a/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
@@ -68,7 +68,7 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
     }
 
     private SymbolType(int arrayCount, List<SymbolType> upperBounds, List<SymbolType> lowerBounds,
-                       String typeVariable) {
+            String typeVariable) {
         this(upperBounds, lowerBounds);
         this.typeVariable = typeVariable;
         this.arrayCount = arrayCount;
@@ -101,7 +101,8 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
         }
     }
 
-    private SymbolType(String name, int arrayCount, List<SymbolType> upperBounds, List<SymbolType> lowerBounds, String typeVariable) {
+    private SymbolType(String name, int arrayCount, List<SymbolType> upperBounds, List<SymbolType> lowerBounds,
+            String typeVariable) {
         this(name, upperBounds, lowerBounds);
         this.typeVariable = typeVariable;
         this.arrayCount = arrayCount;
@@ -259,8 +260,8 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
             SymbolType aux = (SymbolType) o;
             String auxName = aux.getName();
             boolean equalName = name != null && auxName != null && name.equals(auxName);
-            equalName = equalName || (isTemplateVariable() && aux.isTemplateVariable()
-                    && typeVariable.equals(aux.typeVariable));
+            equalName = equalName
+                    || (isTemplateVariable() && aux.isTemplateVariable() && typeVariable.equals(aux.typeVariable));
             return equalName && arrayCount == aux.getArrayCount();
         }
         return false;
@@ -638,7 +639,7 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
      * Builds a symbol for a type variable.
      */
     private static SymbolType typeVariableOf(String typeVariable, final String name, final int arrayCount,
-                                             final List<SymbolType> upperBounds, final List<SymbolType> lowerBounds) {
+            final List<SymbolType> upperBounds, final List<SymbolType> lowerBounds) {
         return new SymbolType(name, arrayCount, upperBounds, lowerBounds, typeVariable);
     }
 
@@ -646,7 +647,7 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
      * Builds a symbol for a type variable.
      */
     private static SymbolType typeVariableOf(final String typeVariable, final int arrayCount,
-                                             List<SymbolType> upperBounds, List<SymbolType> lowerBounds) {
+            List<SymbolType> upperBounds, List<SymbolType> lowerBounds) {
         return new SymbolType(arrayCount, upperBounds, lowerBounds, typeVariable);
     }
 
@@ -834,7 +835,8 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
 
                     arg = returnType;
                 }
-                returnType = typeVariableOf(variableName, arg.getName(), arg.getArrayCount(), arg.getBounds(), arg.getLowerBounds());
+                returnType = typeVariableOf(variableName, arg.getName(), arg.getArrayCount(), arg.getBounds(),
+                        arg.getLowerBounds());
                 Map<String, SymbolType> auxMap = new HashMap<String, SymbolType>(typeMapping);
                 auxMap.put(variableName, returnType);
 

--- a/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolType.java
@@ -892,12 +892,11 @@ public class SymbolType implements SymbolData, MethodSymbolData, FieldSymbolData
     private static SymbolType valueOfParameterizedType(ParameterizedType type, SymbolType arg,
             Map<String, SymbolType> updatedTypeMapping, Map<String, SymbolType> typeMapping)
             throws InvalidTypeException {
-        SymbolType returnType;
-        Class<?> auxClass = (Class<?>) type.getRawType();
+        final Class<?> auxClass = (Class<?>) type.getRawType();
 
-        Type[] types = type.getActualTypeArguments();
+        final Type[] types = type.getActualTypeArguments();
 
-        returnType = new SymbolType(auxClass.getName());
+        final SymbolType returnType = new SymbolType(auxClass.getName());
 
         if (types != null) {
 

--- a/src/main/java/org/walkmod/javalang/compiler/types/TypeVisitorAdapter.java
+++ b/src/main/java/org/walkmod/javalang/compiler/types/TypeVisitorAdapter.java
@@ -144,8 +144,7 @@ public class TypeVisitorAdapter<A extends Map<String, Object>> extends VoidVisit
         n.getName().accept(this, arg);
         n.getIndex().accept(this, arg);
         SymbolType arrayType = (SymbolType) n.getName().getSymbolData();
-        SymbolType newType = new SymbolType();
-        newType.setName(arrayType.getName());
+        SymbolType newType = new SymbolType(arrayType.getName());
         newType.setParameterizedTypes(arrayType.getParameterizedTypes());
         newType.setArrayCount(arrayType.getArrayCount() - 1);
 
@@ -581,8 +580,7 @@ public class TypeVisitorAdapter<A extends Map<String, Object>> extends VoidVisit
                 clazz = TypesLoaderVisitor.getClassLoader().loadClass(n.getName());
 
                 String className = clazz.getName();
-                type = new SymbolType();
-                type.setName(className);
+                type = new SymbolType(className);
 
             } catch (ClassNotFoundException e) {
                 // a name expression could be "org.walkmod.A" and this node
@@ -678,16 +676,17 @@ public class TypeVisitorAdapter<A extends Map<String, Object>> extends VoidVisit
 
     @Override
     public void visit(QualifiedNameExpr n, A arg) {
-        SymbolType type = new SymbolType(n.getName());
+        StringBuilder name = new StringBuilder(n.getName());
         NameExpr aux = n.getQualifier();
         while (aux != null) {
-            type.setName(type.getName() + "." + aux.getName());
+            name.append(".").append(aux.getName());
             if (aux instanceof QualifiedNameExpr) {
                 aux = ((QualifiedNameExpr) aux).getQualifier();
             } else {
                 aux = null;
             }
         }
+        SymbolType type = new SymbolType(name.toString());
         n.setSymbolData(type);
         if (semanticVisitor != null) {
             n.accept(semanticVisitor, arg);


### PR DESCRIPTION
These are changes that reduce the mutable surface of SymbolType and it's usages.
It builds on https://github.com/rpau/javalang-compiler/pull/58.
If that needs rework this needs a rebase. 
There are only 2 uses of "Symboltype.setName" left.
I would like to get rid of "symbol.getType().setName(nameExpr);" in LoadStaticImportsAction.
It's unfortunate that the SymbolType object that is already stored in the Symbol needs tweaking here.
But I don't understand enough of the surrounding code flow there to propose a "good" solution to
improve the general flow.
If you are OK with that I will create a new SymbolType instance at that location and set that new instance
into the "Symbol" via "Symbol.setType". (see 4f4245cf8769d5294ddfeea0e82c7c5e6dab64f9)
That helps to improve SymbolType at least.
The other usage of setName outside of Symboltype  I am investigating.

When we want to remove public setters of SymbolType how to do that?
If external projects depend on them they will break.
Do you know of external usages beyond the other walkmod projects?
How do you test changes like that for the other walkmod projects?
Do you have some automatic way of checking that?
Is there some "maven way" or "travis way" or whatever that tracks new usages of deprecated code?
If yes making the setters deprecated, checking all depdendant projects for new deprecation warnings, fixing them, increasing the minimum version of the javalang-compiler dependency they depend on and at last removing the setter and increasing the version number can be done.
How did you do incompatible changes in the past? 
