### PR TITLE
Formatter config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.classpath
 *.project
 /target/
+.gradle
 .idea
 *.iml
 src/main/*.iml

--- a/formatter.gradle
+++ b/formatter.gradle
@@ -1,0 +1,78 @@
+/*
+ * Minimal gradle build file for calling spotless
+ * java formatter
+ * https://github.com/diffplug/spotless - formatter for java and others 
+ * (tasks: spotlessCheck, spotlessApply resp. spotlessApplyJava)
+ * 
+ * Run via maven:
+ mvn org.fortasoft:gradle-maven-plugin:invoke
+ */
+
+buildscript {
+    repositories {
+        //mavenLocal()
+        mavenCentral()
+        //maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.4.0"
+    }
+}
+
+apply plugin: "com.diffplug.gradle.spotless"
+
+apply plugin: 'java'
+
+compileJava {
+    sourceCompatibility = '1.7'
+}
+
+/*
+ * Code formatter - https://github.com/diffplug/spotless
+ */
+project.plugins.withId('com.diffplug.gradle.spotless') {
+    spotless {
+        format 'misc', {
+            target '**/*.gradle', '**/*.md', '**/.gitignore'
+
+            indentWithSpaces()
+            trimTrailingWhitespace()
+            endWithNewline()
+        }
+
+        // for formatter config see src/config/eclipse/formatter/java.xml
+        java {
+            importOrderFile 'src/config/spotless/spotless.importorder'
+
+            // based on XML file dumped out by the Eclipse formatter
+            eclipse().configFile('src/config/eclipse/formatter/java.xml')
+//            eclipseFormatFile('src/config/eclipse/formatter/java.xml')
+
+            // Note: this may be slow
+            removeUnusedImports()
+
+            indentWithSpaces()
+            trimTrailingWhitespace()
+            endWithNewline()
+
+            // eclipse formatter indents empty lines even if option is set to false.
+            replaceRegex 'Empty line indent fix', '^ +$', ''
+
+            // use standard modifier order (JLS 4.8.7 Modifiers)
+            // public protected private abstract static final transient volatile synchronized native strictfp
+            replaceRegex 'Modifier order 1', '^(\\s*)((?:static)|(?:final)|(?:abstract))\\s+((public)|(protected)|(private))\\s',
+                    '$1$3 $2 '
+            replaceRegex 'Modifier order 2', '^(\\s*)final\\s+static\\s+((public)|(protected)|(private))\\s', '$1$2 static final '
+            replaceRegex 'Modifier order 3', '^(\\s*)static\\s+final\\s+((public)|(protected)|(private))\\s', '$1$2 static final '
+            replaceRegex 'Modifier order 4', '^(\\s*((public)|(protected)|(private))?\\s*)\\sfinal\\s+static', '$1 static final'
+
+            // remove empty lines before end of block (closing "}")
+            replaceRegex 'Remove empty lines before end of block', '\\n[\\n]+(\\s*})(?=\\n)', '\n$1'
+
+            replaceRegex 'Remove trailing empty comment lines.', '\n\\s*\\*(\n\\s*\\*/\n)', '$1'
+            replaceRegex 'Remove empty javadoc param tags.', '\n\\s*\\* @param \\w+\n', '\n'
+            replaceRegex 'Remove empty javadoc return tags.', '\n\\s*\\* @return\n', '\n'
+            replaceRegex 'Replace exception tag with throws tag.', '(\n\\s*\\* )@exception ', '$1@throws '
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,36 @@
                 </executions>
             </plugin>
             <!-- 
-                https://mvnrepository.com/artifact/com.marvinformatics.formatter/formatter-maven-plugin 
-                formatting rules: src/config/eclipse/formatter/java.xml
-                format with: mvn formatter:format
-            -->
+                https://github.com/LendingClub/gradle-maven-plugin
+                plugin is used for integration of spotless java formatter
+                (https://github.com/diffplug/spotless)
+                formatting rules: src/config/eclipse/formatter/java.xml, formatting.gradle
+                format with: mvn org.fortasoft:gradle-maven-plugin:invoke
+             -->
             <plugin>
-                <groupId>com.marvinformatics.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-                <version>1.9.1.RC2</version>
+                <groupId>org.fortasoft</groupId>
+                <artifactId>gradle-maven-plugin</artifactId>
+                <version>1.0.8</version>
+                <configuration>
+                    <tasks>
+                        <task>spotlessJavaApply</task>
+                    </tasks>
+                    <gradleVersion>3.5</gradleVersion>
+                    <args>
+                        <arg>-b</arg>
+                        <arg>formatter.gradle</arg>
+                    </args>
+                </configuration>
+                <executions>
+                    <execution>
+                        <!-- You can bind this to any phase you like -->
+                        <phase>spotless</phase>
+                        <goals>
+                            <!-- goal must be "invoke" -->
+                            <goal>invoke</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/config/eclipse/formatter/java.xml
+++ b/src/config/eclipse/formatter/java.xml
@@ -6,21 +6,43 @@
 
      changes compared to original google java code style version 13:
      -->
+
 <!-- tab size is 4 chars instead of 2 chars -->
 <!-- maximum line length 120 chars instead of 100 -->
 <!-- allow to disable formatter via comment -->
 <!-- only preserve single empty line instead of up to 3 -->
+<!-- single blank line before first class body declaration -->
+<!-- single blank line before member type -->
+<!-- wrap binary expressions when needed on each sub expression -->
 <!-- use same wrapping for "?" and ":" of ?:-Operator. Either none or both.  -->
 <!-- do not format line comments -->
 
 <!--
-    alignments:
-    48: wrap all if necessary, default indent
-    50: when necessary on column
-    82: wrap all but first if necessary, column indent
-    18: wrap where necessary, indent on column
+   Constants:
+       https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+       https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+
+    Alignment modes
+	M_FORCE = 1; // if bit set, then alignment will be non-optional (default is optional)
+	M_INDENT_ON_COLUMN = 2; // if bit set, broken fragments will be aligned on current location column (default is to break at current indentation level)
+	M_INDENT_BY_ONE = 4; // if bit set, broken fragments will be indented one level below current (not using continuation indentation)
+
+    // split modes can be combined either with M_FORCE or M_INDENT_ON_COLUMN
+
+    M_NO_ALIGNMENT = 0 - value to disable alignment
+    M_COMPACT_SPLIT = 16; // fill each line with all possible fragments
+    M_COMPACT_FIRST_BREAK_SPLIT = 32; //  compact mode, but will first try to break before first fragment
+    M_ONE_PER_LINE_SPLIT = 32+16; // one fragment per line
+    M_NEXT_SHIFTED_SPLIT = 64; // one fragment per line, subsequent are indented further
+    M_NEXT_PER_LINE_SPLIT = 64+16; // one per line, except first fragment (if possible)
+
     16: wrap where necessary, default indent
+    18: wrap where necessary, indent on column
     32: Wrap first element, others where necessary (useful for ternary op aka "conditional")
+    48: wrap all, default indent
+    50: when necessary on column
+    80: wrap all but first if necessary (?), default indent (64 + 16)
+    82: wrap all but first if necessary, column indent
     -->
 <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
@@ -57,7 +79,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
 <!-- use same wrapping for "?" and ":" of ?:-Operator. Either none or both. (48 instead of 80)  -->
-<!-- <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/> --> 
+<!-- <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/> -->
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields.count_dependent" value="16|-1|16"/>
@@ -98,7 +120,9 @@
 <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_local_variable_annotation" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+<!-- single blank line before member type -->
+<!-- <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/> -->
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants.count_dependent" value="16|5|48"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
@@ -123,7 +147,9 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<!-- single blank line before first class body declaration -->
+<!-- <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/> -->
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
 <!-- tab size is 4 chars instead of 2 chars -->
 <!-- <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="2"/> -->
@@ -260,7 +286,9 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration.count_dependent" value="16|5|80"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<!-- wrap binary expressions when needed on each sub expression -->
+<!--<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/> -->
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
 <setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
@@ -342,7 +370,7 @@
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|4|48"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_member_annotation" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="1585"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>

--- a/src/config/spotless/spotless.importorder
+++ b/src/config/spotless/spotless.importorder
@@ -1,0 +1,7 @@
+0=java
+1=javax
+2=
+3=org.walkmod
+4=\#java
+5=\#javax
+6=\#

--- a/walkmod.xml
+++ b/walkmod.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE walkmod PUBLIC "-//WALKMOD//DTD" "http://www.walkmod.com/dtd/walkmod-1.0.dtd">
 <walkmod>
     <plugins>


### PR DESCRIPTION
Dear Raquel!

I am sorry for the formatter obstacles.
I tried to translate the formatting config I am familiar with from the gradle formatter to a maven formatter
I was not familiar with and I was not good enough.

This pull requests takes a totally different approach:
Maven calls out to gradle via plugin to execute the gradle plugin "spotless" that does the formatting and 
also removes unused imports.
This uses the formatting utils I am familiar with but does not need a gradle installation or migration. 

The changes compared to the previous configuration:
see   https://github.com/cal101/javalang-compiler/commit/b5be5fd8a5c679e23599c680e811f1c55ebf7c2d

Execute the formatter via 

```mvn org.fortasoft:gradle-maven-plugin:invoke```

The result can also be see here: 
https://github.com/cal101/javalang-compiler/commit/240eda04a0bb6e90bbc0cd4d3d90a9680f00aecc

- A lot of trailing whitespace and blank lines before a block ends are now properly removed.
- Only a few import lines are changed. That means the import order config matches most of the code.

To see the real differences it's best to call the formatter in your own workspace and apply it
and then compare with "git diff -w" to ignore whitespace.

I hope this helps.

Cal
