### PR TITLE
Fix to support MethodReferenceExpr as statements

### DIFF
--- a/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolVisitorAdapter.java
+++ b/src/main/java/org/walkmod/javalang/compiler/symbols/SymbolVisitorAdapter.java
@@ -893,6 +893,10 @@ public class SymbolVisitorAdapter<A extends Map<String, Object>> extends VoidVis
             scopeType = symbolTable.getType("this", ReferenceType.VARIABLE);
         } else {
             scopeType = (SymbolType) n.getScope().getSymbolData();
+            if (scopeType == null) {
+                n.getScope().accept(expressionTypeAnalyzer, arg);
+                scopeType = (SymbolType) n.getScope().getSymbolData();
+            }
         }
         SymbolType[] argsType = (SymbolType[]) n.getReferencedArgsSymbolData();
 


### PR DESCRIPTION
The system was assuming that method references could be only used
from arguments to run lambda expressions.

However, functions such as Supplier can also be instantiated as
method references.

This patch fixes it by recursively analyzing the scope of the scope
if it has not been analyzed before.