### PR TITLE
Fix method reference usages from constructors

### DIFF
--- a/src/main/java/org/walkmod/javalang/compiler/reflection/SymbolDataOfMethodReferenceBuilder.java
+++ b/src/main/java/org/walkmod/javalang/compiler/reflection/SymbolDataOfMethodReferenceBuilder.java
@@ -19,14 +19,27 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.walkmod.javalang.ast.ConstructorSymbolData;
 import org.walkmod.javalang.ast.MethodSymbolData;
 import org.walkmod.javalang.ast.expr.Expression;
 import org.walkmod.javalang.ast.expr.MethodCallExpr;
 import org.walkmod.javalang.ast.expr.MethodReferenceExpr;
+import org.walkmod.javalang.ast.expr.ObjectCreationExpr;
 import org.walkmod.javalang.compiler.symbols.SymbolType;
 import org.walkmod.javalang.visitors.VoidVisitor;
 
-public class SymbolDataOfMethodReferenceBuilder<T> implements TypeMappingBuilder<MethodCallExpr> {
+/**
+ * This component resolves the complete
+ * result type of a method reference when it is used
+ * from a method call or a constructor.
+ *
+ * According the arguments of the resolved methods/constructors, and
+ * the current template variables, it is able to resolve
+ * the complete return type of a method reference
+ * @param <T> of the visitor template parameter that is applied
+ *           to post-process over the updated method reference.
+ */
+public class SymbolDataOfMethodReferenceBuilder<T>  {
 
     private Map<String, SymbolType> typeMapping;
 
@@ -40,67 +53,92 @@ public class SymbolDataOfMethodReferenceBuilder<T> implements TypeMappingBuilder
         this.ctxt = ctxt;
     }
 
-    @Override
-    public MethodCallExpr build(MethodCallExpr n) throws Exception {
+    public void build(ObjectCreationExpr n) throws Exception {
+        List<Expression> args = n.getArgs();
+        ConstructorSymbolData st = n.getSymbolData();
+        if (args != null) {
+
+            if (st == null) {
+                throw new Exception("Ops! The method call " + n.toString() + " is not resolved. The scope is ["
+                        + getScopeName(n.getScope()) + "] , and the args are : " + getArgsDetails(n.getArgs()));
+            }
+
+            java.lang.reflect.Type[] argClasses = st.getConstructor().getGenericParameterTypes();
+            int paramCount = st.getConstructor().getParameterTypes().length;
+            processMethodReferences(paramCount, args, argClasses);
+        }
+    }
+
+    private void processMethodReferences(int paramCount,
+                                         List<Expression> args, java.lang.reflect.Type[] argClasses) throws Exception {
+        int i = 0;
+        for (Expression argument : args) {
+            if (argument instanceof MethodReferenceExpr) {
+                SymbolType aux = null;
+                if (i < paramCount) {
+                    aux = SymbolType.valueOf(argClasses[i], typeMapping);
+
+                } else {
+                    java.lang.reflect.Type componentType = null;
+                    java.lang.reflect.Type lastArg = argClasses[argClasses.length - 1];
+                    if (lastArg instanceof Class<?>) {
+                        componentType = ((Class<?>) lastArg).getComponentType();
+                    } else if (lastArg instanceof GenericArrayType) {
+                        componentType = ((GenericArrayType) lastArg).getGenericComponentType();
+                    }
+                    aux = SymbolType.valueOf(componentType, typeMapping);
+                }
+                argument.setSymbolData(aux);
+                argument.accept(visitor, ctxt);
+            }
+            i++;
+        }
+    }
+
+    public void build(MethodCallExpr n) throws Exception {
         List<Expression> args = n.getArgs();
         MethodSymbolData st = n.getSymbolData();
         if (args != null) {
-            int i = 0;
             if (st == null) {
-                Expression scope = n.getScope();
-                String scopeName = "empty";
-                if (scope != null) {
-                    scopeName = scope.getSymbolData().toString();
-                }
-                String argsTypeName = "empty";
-                List<Expression> argExpr = n.getArgs();
-                if (argExpr != null) {
-                    argsTypeName = "[";
-                    Iterator<Expression> it = argExpr.iterator();
-                    while (it.hasNext()) {
-                        Expression arg = it.next();
-                        if (arg != null && arg.getSymbolData() != null) {
-                            argsTypeName += " " + arg.getSymbolData().toString();
-                        } else {
-                            argsTypeName += " null";
-                        }
-                        if (it.hasNext()) {
-                            argsTypeName += ",";
-                        }
-                    }
-                    argsTypeName += "]";
-                }
                 throw new Exception("Ops! The method call " + n.toString() + " is not resolved. The scope is ["
-                        + scopeName + "] , and the args are : " + argsTypeName);
+                        + getScopeName(n.getScope()) + "] , and the args are : " + getArgsDetails(n.getArgs()));
             }
             java.lang.reflect.Type[] argClasses = st.getMethod().getGenericParameterTypes();
             int paramCount = st.getMethod().getParameterTypes().length;
-            for (Expression argument : args) {
-                if (argument instanceof MethodReferenceExpr) {
-                    SymbolType aux = null;
-                    if (i < paramCount) {
-                        aux = SymbolType.valueOf(argClasses[i], typeMapping);
-
-                    } else {
-                        java.lang.reflect.Type componentType = null;
-                        java.lang.reflect.Type lastArg = argClasses[argClasses.length - 1];
-                        if (lastArg instanceof Class<?>) {
-                            componentType = ((Class<?>) lastArg).getComponentType();
-                        } else if (lastArg instanceof GenericArrayType) {
-                            componentType = ((GenericArrayType) lastArg).getGenericComponentType();
-                        }
-                        aux = SymbolType.valueOf(componentType, typeMapping);
-                    }
-                    argument.setSymbolData(aux);
-                    argument.accept(visitor, ctxt);
-                }
-                i++;
-            }
+            processMethodReferences(paramCount, args, argClasses);
         }
-        return null;
     }
 
-    @Override
+
+    private String getScopeName(Expression scope) {
+        String scopeName = "empty";
+        if (scope != null) {
+            scopeName = scope.getSymbolData().toString();
+        }
+        return scopeName;
+    }
+
+    private String getArgsDetails(List<Expression> argExpr) {
+        String argsTypeName = "empty";
+        if (argExpr != null) {
+            argsTypeName = "[";
+            Iterator<Expression> it = argExpr.iterator();
+            while (it.hasNext()) {
+                Expression arg = it.next();
+                if (arg != null && arg.getSymbolData() != null) {
+                    argsTypeName += " " + arg.getSymbolData().toString();
+                } else {
+                    argsTypeName += " null";
+                }
+                if (it.hasNext()) {
+                    argsTypeName += ",";
+                }
+            }
+            argsTypeName += "]";
+        }
+        return argsTypeName;
+    }
+
     public void setTypeMapping(Map<String, SymbolType> typeMapping) {
         this.typeMapping = typeMapping;
     }

--- a/src/main/java/org/walkmod/javalang/compiler/types/TypeVisitorAdapter.java
+++ b/src/main/java/org/walkmod/javalang/compiler/types/TypeVisitorAdapter.java
@@ -612,7 +612,16 @@ public class TypeVisitorAdapter<A extends Map<String, Object>> extends VoidVisit
         if (!AnonymousClassUtil.isAnonymousClass(n) || AnonymousClassUtil.needsSymbolData(n)) {
             SymbolType st = (SymbolType) n.getType().getSymbolData();
             resolveConstructor(n, n.getArgs(), st, arg);
+
+            try {
+                SymbolDataOfMethodReferenceBuilder<A> typeBuilder =
+                        new SymbolDataOfMethodReferenceBuilder<A>(new HashMap<String, SymbolType>(), this, arg);
+                typeBuilder.build(n);
+            } catch (Exception e) {
+                throw new NoSuchExpressionTypeException(e);
+            }
         }
+
 
         // we need to update the symbol table
         if (semanticVisitor != null) {
@@ -672,6 +681,7 @@ public class TypeVisitorAdapter<A extends Map<String, Object>> extends VoidVisit
         try {
             SymbolType aux = ConstructorInspector.findConstructor(st, symbolTypes, filter, builder, typeMapping);
             n.setSymbolData(aux);
+
         } catch (Exception e) {
             throw new NoSuchExpressionTypeException(e);
         }

--- a/src/test/java/org/walkmod/javalang/compiler/SymbolVisitorAdapterTest.java
+++ b/src/test/java/org/walkmod/javalang/compiler/SymbolVisitorAdapterTest.java
@@ -2625,4 +2625,31 @@ public class SymbolVisitorAdapterTest extends SymbolVisitorAdapterTestSupport {
                     ((MethodDeclaration) cu.getTypes().get(0).getMembers().get(2)).getUsages().size());
         }
     }
+
+    @Test
+    public void testDontRemoveImportsUsedByLambdas() throws Exception {
+        if (SourceVersion.latestSupported().ordinal() >= 8) {
+            String code = "package example;" +
+                    "import java.util.function.Supplier;" +
+                    "public class ExampleDefaultTemplateManager {" +
+                    "public ExampleDefaultTemplateManager() {" +
+                    "ContextFreeReference<Object> holderRef = new ContextFreeReference<>(this::initTemplates);" +
+                    "}" +
+                    "private Object initTemplates() {" +
+                    "return null;" +
+                    "}" +
+
+                    "public class ContextFreeReference<T> implements Supplier<T> {" +
+                    "public ContextFreeReference(Supplier<T> supplier) {" +
+                    "}" +
+                    "public T get() {" +
+                    "return null;" +
+                    "}" +
+                    "}" +
+                    "}";
+            CompilationUnit cu = run(code);
+            Assert.assertEquals(1,
+                    ((MethodDeclaration) cu.getTypes().get(0).getMembers().get(1)).getUsages().size());
+        }
+    }
 }


### PR DESCRIPTION
This patch fixes that method references do not have
usages when they are constructor arguments.

The method reference symbols are resolved in
SymbolDataOfMethodReferenceBuilder which was only
used in the visit method of TypeVisitorAdapter
 for MethodCallExpr.

This patch adaptes SymbolDataOfMethodReferenceBuilder
to support constructors and the visit method of
ObjectCreationExpr is also updated to use
this component.