### PR TITLE
Testcases to recreate the scenario where method usage not recognised …

### DIFF
--- a/src/test/java/org/walkmod/javalang/compiler/SymbolVisitorAdapterTest.java
+++ b/src/test/java/org/walkmod/javalang/compiler/SymbolVisitorAdapterTest.java
@@ -2679,4 +2679,40 @@ public class SymbolVisitorAdapterTest extends SymbolVisitorAdapterTestSupport {
         Assert.assertEquals(1, cu.getImports().get(1).getUsages().size());
         Assert.assertEquals(1, cu.getImports().get(2).getUsages().size());
     }
+
+    @Test
+    public void testMethodUsageWhenUsedInLambda1() throws Exception {
+                       String code = "package example;" +
+                                 "public class ExampleCheck {" +
+                               "public boolean check(java.util.Map<String, Object> trials) { " +
+                                                "return new java.util.ArrayList<String>().stream() " +
+                                                    ".map(trials::get) " +
+                                                    ".anyMatch(this::isPaid); " +
+                                            "}" +
+                               "private boolean isPaid(final Object date) {" +
+                                    "return true;" +
+                               "}" +
+                               "}";
+        CompilationUnit cu = run(code);
+        Assert.assertNull(((MethodDeclaration)cu.getTypes().get(0).getMembers().get(0)).getUsages());
+        Assert.assertEquals(1, ((MethodDeclaration)cu.getTypes().get(0).getMembers().get(1)).getUsages().size());
+    }
+
+    @Test
+    public void testMethodUsageWhenUsedInLambda2() throws Exception {
+        String code = "package example;" +
+                "public class ExampleCheck {" +
+                "public boolean check(java.util.Map<String, java.time.LocalDate> trials) { " +
+                "return new java.util.ArrayList<String>().stream() " +
+                ".map(trials::get) " +
+                ".anyMatch(this::isPaid); " +
+                "}" +
+                "private boolean isPaid(final java.time.LocalDate date) {" +
+                "return true;" +
+                "}" +
+                "}";
+        CompilationUnit cu = run(code);
+        Assert.assertNull(((MethodDeclaration)cu.getTypes().get(0).getMembers().get(0)).getUsages());
+        Assert.assertEquals(1, ((MethodDeclaration)cu.getTypes().get(0).getMembers().get(1)).getUsages().size());
+    }
 }


### PR DESCRIPTION
…when a non-Object parameter is used, testMethodUsageWhenUsedInLambda1() passes whereas testMethodUsageWhenUsedInLambda2() does not. I would expect both to pass. This is causing the walkmod-dead-code-cleaner-plugin to pick up more code to delete than it should